### PR TITLE
Added installation how-to to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,15 @@ This patch removes the 'No valid subscription' warning in Proxmox VE and should 
 in test or demo environments. Please consider [buying a subscription](https://www.proxmox.com/en/proxmox-ve/pricing)
 and supporting the development of Proxmox VE.
 
+## How to install
+
+Navigate to the [releases](https://github.com/lnxbil/pve-no-subscription/releases), copy the link to the latest .deb package. On your Proxmox server, download and then install the package, e.g.
+```
+wget https://github.com/lnxbil/pve-no-subscription/releases/download/1.5/pve-no-subscription_1.5_all.deb
+dpkg -i pve-no-subscription_1.5_all.deb
+```
+Navigate to your Proxmox web interface, then refresh. If necessary, clear your browser cache. 
+
 
 ## Technical Implementation
 


### PR DESCRIPTION
Hi,
I added a paragraph on how to install the package. While it is obvious in hindsight, it was not clear to me initially–also due to the Github redesign in which I had to search for the releases whilst already actively looking for it.